### PR TITLE
Modify Find/LowerBound/UpperBound apis.

### DIFF
--- a/common.go
+++ b/common.go
@@ -7,9 +7,6 @@ type Pair[K any, V any] interface {
 
 	// Value Returns the value associated with the pair. Will return the zero value for V if IsEmpty is true.
 	Value() V
-
-	// IsEmpty returns true iif the pair is empty.
-	IsEmpty() bool
 }
 
 // Iterator defines an interface for an iterator over a persistent data structure.

--- a/set.go
+++ b/set.go
@@ -23,7 +23,7 @@ func (s *Set[T]) Contains(elem T) bool {
 	if s != nil {
 		currentRoot = s.tree
 	}
-	return !currentRoot.Find(elem).IsEmpty()
+	return currentRoot.Contains(elem)
 }
 
 //Remove returns the root of a new tree with the given element removed.
@@ -67,8 +67,12 @@ func (s *Set[T]) LeastUpperBound(value T) (e T, ok bool) {
 		return ret, false
 	}
 
-	n := s.tree.LeastUpperBound(value)
-	return n.Key(), !n.IsEmpty()
+	kv, found := s.tree.LeastUpperBound(value)
+	if !found {
+		var ret T
+		return ret, false
+	}
+	return kv.Key(), true
 }
 
 //GreatestLowerBound returns the largest element e in s, such that
@@ -79,8 +83,12 @@ func (s *Set[T]) GreatestLowerBound(value T) (T, bool) {
 		return ret, false
 	}
 
-	n := s.tree.GreatestLowerBound(value)
-	return n.Key(), !n.IsEmpty()
+	kv, found := s.tree.GreatestLowerBound(value)
+	if !found {
+		var ret T
+		return ret, false
+	}
+	return kv.Key(), true
 }
 
 //Size returns the number of elements in the set.

--- a/setEx.go
+++ b/setEx.go
@@ -22,7 +22,7 @@ func (s *SetEx[T]) Contains(elem T) bool {
 	if s != nil {
 		currentRoot = s.tree
 	}
-	return !currentRoot.Find(elem).IsEmpty()
+	return currentRoot.Contains(elem)
 }
 
 //Remove returns the root of a new tree with the given element removed.
@@ -66,8 +66,12 @@ func (s *SetEx[T]) LeastUpperBound(value T) (e T, ok bool) {
 		return ret, false
 	}
 
-	n := s.tree.LeastUpperBound(value)
-	return n.Key(), !n.IsEmpty()
+	kv, found := s.tree.LeastUpperBound(value)
+	if !found {
+		var ret T
+		return ret, false
+	}
+	return kv.Key(), true
 }
 
 //GreatestLowerBound returns the largest element e in s, such that
@@ -78,8 +82,12 @@ func (s *SetEx[T]) GreatestLowerBound(value T) (T, bool) {
 		return ret, false
 	}
 
-	n := s.tree.GreatestLowerBound(value)
-	return n.Key(), !n.IsEmpty()
+	kv, found := s.tree.GreatestLowerBound(value)
+	if !found {
+		var ret T
+		return ret, false
+	}
+	return kv.Key(), true
 }
 
 //Size returns the number of elements in the set.

--- a/tree.go
+++ b/tree.go
@@ -62,21 +62,35 @@ func (n *Tree[K, V]) IsEmpty() bool {
 	return n == nil || n.size == 0
 }
 
-// Find returns the pair associated with key in the tree. Will return an empty pair if no such item exists.
-func (n *Tree[K, V]) Find(key K) Pair[K, V] {
+// Contains returns true if the tree contains the key.
+func (n *Tree[K, V]) Contains(key K) bool {
+	_, found := n.FindOpt(key)
+	return found
+}
+
+// Find returns the value associated with key in the tree. Will return a zero value if no such item exists.
+func (n *Tree[K, V]) Find(key K) V {
+	value, _ := n.FindOpt(key)
+	return value
+}
+
+// FindOpt returns the value associated with key in the tree. Returns true if found; otherwise false.
+// Zero value is returned when found is false.
+func (n *Tree[K, V]) FindOpt(key K) (V, bool) {
 	if n.IsEmpty() {
-		return n
+		var ret V
+		return ret, false
 	}
 
 	if n.key < key {
-		return n.right.Find(key)
+		return n.right.FindOpt(key)
 	}
 
 	if key < n.key {
-		return n.left.Find(key)
+		return n.left.FindOpt(key)
 	}
 
-	return n
+	return n.value, true
 }
 
 func newNode[K constraints.Ordered, V any](left *Tree[K, V], right *Tree[K, V], key K, value V) *Tree[K, V] {
@@ -277,10 +291,10 @@ func (n *Tree[K, V]) Size() int {
 }
 
 //LeastUpperBound returns the key-value-pair for the smallest node n such that n.Key() >= key. If there is no such
-//node then an empty pair is returned.
-func (n *Tree[K, V]) LeastUpperBound(key K) Pair[K, V] {
+//node then boolean is false.
+func (n *Tree[K, V]) LeastUpperBound(key K) (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n
+		return n, false
 	}
 
 	if n.key < key {
@@ -288,38 +302,37 @@ func (n *Tree[K, V]) LeastUpperBound(key K) Pair[K, V] {
 	}
 
 	if key < n.key {
-		ret := n.left.LeastUpperBound(key)
+		ret, found := n.left.LeastUpperBound(key)
 
-		if ret.IsEmpty() {
-			return n
+		if !found {
+			return n, true
 		}
-		return ret
+		return ret, true
 	}
 
-	return n
+	return n, true
 }
 
 //GreatestLowerBound returns the key-value-par for the largest node n such that n.Key() <= key. If there is no such
-//node than an empty pair is returned.
-func (n *Tree[K, V]) GreatestLowerBound(key K) Pair[K, V] {
+//node then boolean is false.
+func (n *Tree[K, V]) GreatestLowerBound(key K) (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n
+		return n, false
 	}
 
 	if n.key < key {
-		ret := n.right.GreatestLowerBound(key)
-
-		if ret.IsEmpty() {
-			return n
+		ret, found := n.right.GreatestLowerBound(key)
+		if !found {
+			return n, true
 		}
-		return ret
+		return ret, true
 	}
 
 	if key < n.key {
 		return n.left.GreatestLowerBound(key)
 	}
 
-	return n
+	return n, true
 }
 
 //Iter returns an in-order iterator for the tree.
@@ -358,11 +371,11 @@ func (n *Tree[K, V]) IterGte(glb K) Iterator[Pair[K, V]] {
 	return &ret
 }
 
-//Least returns the key-value-pair for the lowest element in the tree. If the tree is empty, the returned pair
-//is also empty.
-func (n *Tree[K, V]) Least() Pair[K, V] {
+//Least returns the key-value-pair for the lowest element in the tree. If the tree is empty then boolean
+//is false
+func (n *Tree[K, V]) Least() (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n
+		return nil, false
 	}
 
 	var ret = n
@@ -371,14 +384,13 @@ func (n *Tree[K, V]) Least() Pair[K, V] {
 		ret = ret.left
 	}
 
-	return ret
+	return ret, true
 }
 
-//Most returns the key-value-pair for the greatest element in the tree. If the tree is empty, the returned pair
-//is also empty
-func (n *Tree[K, V]) Most() Pair[K, V] {
+//Most returns the key-value-pair for the greatest element in the tree. If the tree is empty then boolean is false
+func (n *Tree[K, V]) Most() (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n
+		return nil, false
 	}
 
 	var ret = n
@@ -387,7 +399,7 @@ func (n *Tree[K, V]) Most() Pair[K, V] {
 		ret = ret.right
 	}
 
-	return ret
+	return ret, false
 }
 
 func (n *Tree[K, V]) MarshalJSON() ([]byte, error) {

--- a/treeEx.go
+++ b/treeEx.go
@@ -50,21 +50,35 @@ func (n *TreeEx[K, V]) IsEmpty() bool {
 	return n == nil || n.size == 0
 }
 
-// Find returns the pair associated with key in the tree. Will return an empty pair if no such item exists.
-func (n *TreeEx[K, V]) Find(key K) Pair[K, V] {
+// Contains returns true if the tree contains the key.
+func (n *TreeEx[K, V]) Contains(key K) bool {
+	_, found := n.FindOpt(key)
+	return found
+}
+
+// Find returns the pair associated with key in the tree. Will return a zero value if no such item exists.
+func (n *TreeEx[K, V]) Find(key K) V {
+	value, _ := n.FindOpt(key)
+	return value
+}
+
+// FindOpt returns the pair associated with key in the tree. Return true if found; otherwise false.
+// Zero value is returned when found is false.
+func (n *TreeEx[K, V]) FindOpt(key K) (V, bool) {
 	if n.IsEmpty() {
-		return n
+		var ret V
+		return ret, false
 	}
 
 	if n.key.Less(key) {
-		return n.right.Find(key)
+		return n.right.FindOpt(key)
 	}
 
 	if key.Less(n.key) {
-		return n.left.Find(key)
+		return n.left.FindOpt(key)
 	}
 
-	return n
+	return n.value, true
 }
 
 func newExNode[K Ordered[K], V any](left *TreeEx[K, V], right *TreeEx[K, V], key K, value V) *TreeEx[K, V] {
@@ -279,10 +293,10 @@ func (n *TreeEx[K, V]) Size() int {
 }
 
 //LeastUpperBound returns the key-value-pair for the smallest node n such that n.Key() >= key. If there is no such
-//node then an empty pair is returned.
-func (n *TreeEx[K, V]) LeastUpperBound(key K) Pair[K, V] {
+//node then false is returned.
+func (n *TreeEx[K, V]) LeastUpperBound(key K) (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n
+		return n, false
 	}
 
 	if n.key.Less(key) {
@@ -290,38 +304,37 @@ func (n *TreeEx[K, V]) LeastUpperBound(key K) Pair[K, V] {
 	}
 
 	if key.Less(n.key) {
-		ret := n.left.LeastUpperBound(key)
+		ret, found := n.left.LeastUpperBound(key)
 
-		if ret.IsEmpty() {
-			return n
+		if !found {
+			return n, true
 		}
-		return ret
+		return ret, true
 	}
 
-	return n
+	return n, true
 }
 
 //GreatestLowerBound returns the key-value-par for the largest node n such that n.Key() <= key. If there is no such
-//node than an empty pair is returned.
-func (n *TreeEx[K, V]) GreatestLowerBound(key K) Pair[K, V] {
+//node then false is returned.
+func (n *TreeEx[K, V]) GreatestLowerBound(key K) (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n
+		return n, false
 	}
 
 	if n.key.Less(key) {
-		ret := n.right.GreatestLowerBound(key)
-
-		if ret.IsEmpty() {
-			return n
+		ret, found := n.right.GreatestLowerBound(key)
+		if !found {
+			return n, true
 		}
-		return ret
+		return ret, true
 	}
 
 	if key.Less(n.key) {
 		return n.left.GreatestLowerBound(key)
 	}
 
-	return n
+	return n, true
 }
 
 //Iter returns an in-order iterator for the tree.
@@ -360,11 +373,10 @@ func (n *TreeEx[K, V]) IterGte(glb K) Iterator[Pair[K, V]] {
 	return &ret
 }
 
-//Least returns the key-value-pair for the lowest element in the tree. If the tree is empty, the returned pair
-//is also empty.
-func (n *TreeEx[K, V]) Least() Pair[K, V] {
+//Least returns the key-value-pair for the lowest element in the tree. If the tree is empty, then return false
+func (n *TreeEx[K, V]) Least() (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n
+		return nil, false
 	}
 
 	var ret = n
@@ -373,14 +385,14 @@ func (n *TreeEx[K, V]) Least() Pair[K, V] {
 		ret = ret.left
 	}
 
-	return ret
+	return ret, true
 }
 
 //Most returns the key-value-pair for the greatest element in the tree. If the tree is empty, the returned pair
 //is also empty
-func (n *TreeEx[K, V]) Most() Pair[K, V] {
+func (n *TreeEx[K, V]) Most() (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n
+		return nil, false
 	}
 
 	var ret = n
@@ -389,7 +401,7 @@ func (n *TreeEx[K, V]) Most() Pair[K, V] {
 		ret = ret.right
 	}
 
-	return ret
+	return ret, true
 }
 
 func (n *TreeEx[K, V]) MarshalJSON() ([]byte, error) {

--- a/treeEx_test.go
+++ b/treeEx_test.go
@@ -50,24 +50,18 @@ func TestExDefaultSize(t *testing.T) {
 
 func TestExNilFind(t *testing.T) {
 	var tree *TreeEx[Int, int]
-	p := tree.Find(2)
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	c := tree.Contains(2)
+	v := tree.Find(2)
+	require.Falsef(t, c, "wtf?")
+	require.Zero(t, v)
 }
 
 func TestExEmptyFind(t *testing.T) {
 	var tree TreeEx[Int, int]
-	p := tree.Find(2)
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	c := tree.Contains(2)
+	v := tree.Find(2)
+	require.Falsef(t, c, "wtf?")
+	require.Zero(t, v)
 }
 
 func TestExNilDelete(t *testing.T) {
@@ -84,34 +78,30 @@ func TestExEmptyDelete(t *testing.T) {
 
 func TestExNilGLB(t *testing.T) {
 	var tree *TreeEx[Int, int]
-	p := tree.GreatestLowerBound(2)
-	require.True(t, p.IsEmpty())
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 0, p.Value())
+	kv, found := tree.GreatestLowerBound(2)
+	require.Falsef(t, found, "wtf?")
+	require.Nil(t, kv)
 }
 
 func TestExEmptyGLB(t *testing.T) {
 	var tree TreeEx[Int, int]
-	p := tree.GreatestLowerBound(2)
-	require.True(t, p.IsEmpty())
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 0, p.Value())
+	kv, found := tree.GreatestLowerBound(2)
+	require.Falsef(t, found, "wtf?")
+	require.Equal(t, &TreeEx[Int, int]{}, kv)
 }
 
 func TestExNilLUB(t *testing.T) {
 	var tree *TreeEx[Int, int]
-	p := tree.LeastUpperBound(2)
-	require.True(t, p.IsEmpty())
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 0, p.Value())
+	kv, found := tree.LeastUpperBound(2)
+	require.Falsef(t, found, "wtf?")
+	require.Nil(t, kv)
 }
 
 func TestExEmptyLUB(t *testing.T) {
 	var tree TreeEx[Int, int]
-	p := tree.LeastUpperBound(2)
-	require.True(t, p.IsEmpty())
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 0, p.Value())
+	kv, found := tree.LeastUpperBound(2)
+	require.Falsef(t, found, "wtf?")
+	require.Equal(t, &TreeEx[Int, int]{}, kv)
 }
 
 func TestExNilIter(t *testing.T) {
@@ -180,46 +170,32 @@ func TestExEmptyValue(t *testing.T) {
 
 func TestExNilLeast(t *testing.T) {
 	var tree *TreeEx[Int, int]
-	p := tree.Least()
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	kv, found := tree.Least()
+	require.False(t, found)
+	require.Nil(t, kv)
 }
 
 func TestExEmptyLeast(t *testing.T) {
 	var tree TreeEx[Int, int]
-	p := tree.Least()
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	kv, found := tree.Least()
+	require.False(t, found)
+	require.Nil(t, kv)
+
 }
 
 func TestExNilMost(t *testing.T) {
 	var tree *TreeEx[Int, int]
-	p := tree.Most()
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	kv, found := tree.Most()
+	require.Falsef(t, found, "wtf?")
+	require.Nil(t, kv)
+
 }
 
 func TestExEmptyMost(t *testing.T) {
 	var tree TreeEx[Int, int]
-	p := tree.Most()
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	kv, found := tree.Most()
+	require.Falsef(t, found, "wtf?")
+	require.Nil(t, kv)
 }
 
 func TestExNilUpdate(t *testing.T) {
@@ -231,17 +207,19 @@ func TestExNilUpdate(t *testing.T) {
 	require.Equal(t, 1, tree2.Height())
 	require.Equal(t, Int(2), tree2.Key())
 	require.Equal(t, 3, tree2.Value())
-	p := tree2.Find(4)
-	if p == nil {
-		require.Fail(t, "wtf")
-	}
-	require.True(t, p.IsEmpty())
-	p = tree2.Find(2)
-	require.False(t, p.IsEmpty())
-	require.Equal(t, Int(2), p.Key())
-	require.Equal(t, 3, p.Value())
-	p = tree2.Find(1)
-	require.True(t, p.IsEmpty())
+	c := tree2.Contains(4)
+	v := tree2.Find(4)
+	require.Falsef(t, c, "wtf")
+	require.Zero(t, v)
+
+	c = tree2.Contains(2)
+	v = tree2.Find(2)
+	require.True(t, c)
+	require.Equal(t, 3, v)
+	c = tree2.Contains(1)
+	v = tree2.Find(1)
+	require.False(t, c)
+	require.Zero(t, v)
 	i := tree2.Iter()
 	require.True(t, i.Next())
 	require.Equal(t, Int(2), i.Current().Key())
@@ -258,17 +236,22 @@ func TestExEmptyUpdate(t *testing.T) {
 	require.Equal(t, 1, tree2.Height())
 	require.Equal(t, Int(2), tree2.Key())
 	require.Equal(t, 3, tree2.Value())
-	p := tree2.Find(4)
-	if p == nil {
-		require.Fail(t, "wtf")
-	}
-	require.True(t, p.IsEmpty())
-	p = tree2.Find(2)
-	require.False(t, p.IsEmpty())
-	require.Equal(t, Int(2), p.Key())
-	require.Equal(t, 3, p.Value())
-	p = tree2.Find(1)
-	require.True(t, p.IsEmpty())
+	c := tree2.Contains(4)
+	v := tree2.Find(4)
+	require.False(t, c)
+	require.Zero(t, v)
+	v, c = tree2.FindOpt(4)
+	require.False(t, c)
+	require.Zero(t, v)
+	c = tree2.Contains(2)
+	v = tree2.Find(2)
+	require.True(t, c)
+	require.Equal(t, 3, v)
+	v, c = tree2.FindOpt(2)
+	require.True(t, c)
+	require.Equal(t, 3, v)
+	v = tree2.Find(1)
+	require.Zero(t, v)
 	i := tree2.Iter()
 	require.True(t, i.Next())
 	require.Equal(t, Int(2), i.Current().Key())
@@ -282,10 +265,11 @@ func TestExUpdateReplace(t *testing.T) {
 	tree3 := tree2.Update(0, 10)
 	require.NotEqual(t, tree, tree2)
 	require.NotEqual(t, tree2, tree3)
-	p := tree3.Find(0)
-	require.False(t, p.IsEmpty())
-	require.Equal(t, Int(0), p.Key())
-	require.Equal(t, 10, p.Value())
+	c := tree3.Contains(0)
+	v := tree3.Find(0)
+	require.True(t, c)
+	require.Equal(t, 10, v)
+
 	require.False(t, tree3.Left().IsEmpty())
 	require.False(t, tree3.Right().IsEmpty())
 	require.True(t, tree3.Left().Left().IsEmpty())
@@ -346,13 +330,13 @@ func TestExLeastUpperBound(t *testing.T) {
 	for i := 0; i < 20; i += 2 {
 		tree = tree.Update(Int(i), i)
 	}
-	p := tree.LeastUpperBound(4)
+	p, _ := tree.LeastUpperBound(4)
 	require.Equal(t, 4, p.Value())
-	p = tree.LeastUpperBound(5)
+	p, _ = tree.LeastUpperBound(5)
 	require.Equal(t, 6, p.Value())
-	p = tree.LeastUpperBound(22)
-	require.True(t, p.IsEmpty())
-	p = tree.LeastUpperBound(-1)
+	_, found := tree.LeastUpperBound(22)
+	require.False(t, found)
+	p, _ = tree.LeastUpperBound(-1)
 	require.Equal(t, 0, p.Value())
 }
 
@@ -361,14 +345,14 @@ func TestExGreatestLowerBound(t *testing.T) {
 	for i := 0; i < 20; i += 2 {
 		tree = tree.Update(Int(i), i)
 	}
-	p := tree.GreatestLowerBound(4)
+	p, _ := tree.GreatestLowerBound(4)
 	require.Equal(t, 4, p.Value())
-	p = tree.GreatestLowerBound(5)
+	p, _ = tree.GreatestLowerBound(5)
 	require.Equal(t, 4, p.Value())
-	p = tree.GreatestLowerBound(22)
+	p, _ = tree.GreatestLowerBound(22)
 	require.Equal(t, 18, p.Value())
-	p = tree.GreatestLowerBound(-1)
-	require.True(t, p.IsEmpty())
+	_, found := tree.GreatestLowerBound(-1)
+	require.False(t, found)
 }
 
 func TestExIter(t *testing.T) {
@@ -464,6 +448,7 @@ func TestExUnMarshalJsonStringKey(t *testing.T) {
 	var x *TreeEx[String, int]
 	err = json.Unmarshal(serialized, &x)
 	require.NoError(t, err)
-	require.Equal(t, 2, x.Find("Hello").Value())
-	require.Equal(t, 4, x.Find("World").Value())
+
+	require.Equal(t, 2, x.Find("Hello"))
+	require.Equal(t, 4, x.Find("World"))
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -38,24 +38,20 @@ func TestDefaultSize(t *testing.T) {
 
 func TestNilFind(t *testing.T) {
 	var tree *Tree[int, int]
-	p := tree.Find(2)
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	v := tree.Find(2)
+	c := tree.Contains(2)
+
+	require.Falsef(t, c, "wtf?")
+	require.Zero(t, v)
 }
 
 func TestEmptyFind(t *testing.T) {
 	var tree Tree[int, int]
-	p := tree.Find(2)
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	v := tree.Find(2)
+	c := tree.Contains(2)
+
+	require.Falsef(t, c, "wtf?")
+	require.Zero(t, v)
 }
 
 func TestNilDelete(t *testing.T) {
@@ -72,34 +68,30 @@ func TestEmptyDelete(t *testing.T) {
 
 func TestNilGLB(t *testing.T) {
 	var tree *Tree[int, int]
-	p := tree.GreatestLowerBound(2)
-	require.True(t, p.IsEmpty())
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 0, p.Value())
+	kv, found := tree.GreatestLowerBound(2)
+	require.False(t, found)
+	require.Nil(t, kv)
 }
 
 func TestEmptyGLB(t *testing.T) {
 	var tree Tree[int, int]
-	p := tree.GreatestLowerBound(2)
-	require.True(t, p.IsEmpty())
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 0, p.Value())
+	kv, found := tree.GreatestLowerBound(2)
+	require.False(t, found)
+	require.Equal(t, &Tree[int, int]{}, kv)
 }
 
 func TestNilLUB(t *testing.T) {
 	var tree *Tree[int, int]
-	p := tree.LeastUpperBound(2)
-	require.True(t, p.IsEmpty())
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 0, p.Value())
+	kv, found := tree.LeastUpperBound(2)
+	require.False(t, found)
+	require.Nil(t, kv)
 }
 
 func TestEmptyLUB(t *testing.T) {
 	var tree Tree[int, int]
-	p := tree.LeastUpperBound(2)
-	require.True(t, p.IsEmpty())
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 0, p.Value())
+	kv, found := tree.LeastUpperBound(2)
+	require.False(t, found)
+	require.Equal(t, &Tree[int, int]{}, kv)
 }
 
 func TestNilIter(t *testing.T) {
@@ -168,46 +160,30 @@ func TestEmptyValue(t *testing.T) {
 
 func TestNilLeast(t *testing.T) {
 	var tree *Tree[int, int]
-	p := tree.Least()
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	v, found := tree.Least()
+	require.Falsef(t, found, "wtf?")
+	require.Zero(t, 0, v)
 }
 
 func TestEmptyLeast(t *testing.T) {
 	var tree Tree[int, int]
-	p := tree.Least()
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	v, found := tree.Least()
+	require.Falsef(t, found, "wtf?")
+	require.Zero(t, 0, v)
 }
 
 func TestNilMost(t *testing.T) {
 	var tree *Tree[int, int]
-	p := tree.Most()
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	v, found := tree.Most()
+	require.Falsef(t, found, "wtf?")
+	require.Zero(t, 0, v)
 }
 
 func TestEmptyMost(t *testing.T) {
 	var tree Tree[int, int]
-	p := tree.Most()
-	if p == nil {
-		require.Fail(t, "wtf?")
-	}
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 0, p.Value())
-	require.True(t, p.IsEmpty())
+	v, found := tree.Most()
+	require.Falsef(t, found, "wtf?")
+	require.Zero(t, 0, v)
 }
 
 func TestNilUpdate(t *testing.T) {
@@ -219,17 +195,17 @@ func TestNilUpdate(t *testing.T) {
 	require.Equal(t, 1, tree2.Height())
 	require.Equal(t, 2, tree2.Key())
 	require.Equal(t, 3, tree2.Value())
-	p := tree2.Find(4)
-	if p == nil {
-		require.Fail(t, "wtf")
-	}
-	require.True(t, p.IsEmpty())
-	p = tree2.Find(2)
-	require.False(t, p.IsEmpty())
-	require.Equal(t, 2, p.Key())
-	require.Equal(t, 3, p.Value())
-	p = tree2.Find(1)
-	require.True(t, p.IsEmpty())
+	c := tree2.Contains(4)
+	require.Falsef(t, c, "wtf")
+
+	v := tree2.Find(2)
+	c = tree2.Contains(2)
+	require.True(t, c)
+	require.Equal(t, 3, v)
+
+	c = tree2.Contains(1)
+	require.False(t, c)
+
 	i := tree2.Iter()
 	require.True(t, i.Next())
 	require.Equal(t, 2, i.Current().Key())
@@ -246,17 +222,17 @@ func TestEmptyUpdate(t *testing.T) {
 	require.Equal(t, 1, tree2.Height())
 	require.Equal(t, 2, tree2.Key())
 	require.Equal(t, 3, tree2.Value())
-	p := tree2.Find(4)
-	if p == nil {
-		require.Fail(t, "wtf")
-	}
-	require.True(t, p.IsEmpty())
-	p = tree2.Find(2)
-	require.False(t, p.IsEmpty())
-	require.Equal(t, 2, p.Key())
-	require.Equal(t, 3, p.Value())
-	p = tree2.Find(1)
-	require.True(t, p.IsEmpty())
+	c := tree2.Contains(4)
+	require.Falsef(t, c, "wtf")
+
+	v := tree2.Find(2)
+	c = tree2.Contains(2)
+	require.True(t, c)
+	require.Equal(t, 3, v)
+
+	c = tree2.Contains(1)
+	require.False(t, c)
+
 	i := tree2.Iter()
 	require.True(t, i.Next())
 	require.Equal(t, 2, i.Current().Key())
@@ -270,10 +246,10 @@ func TestUpdateReplace(t *testing.T) {
 	tree3 := tree2.Update(0, 10)
 	require.NotEqual(t, tree, tree2)
 	require.NotEqual(t, tree2, tree3)
-	p := tree3.Find(0)
-	require.False(t, p.IsEmpty())
-	require.Equal(t, 0, p.Key())
-	require.Equal(t, 10, p.Value())
+	v := tree3.Find(0)
+	c := tree3.Contains(0)
+	require.True(t, c)
+	require.Equal(t, 10, v)
 	require.False(t, tree3.Left().IsEmpty())
 	require.False(t, tree3.Right().IsEmpty())
 	require.True(t, tree3.Left().Left().IsEmpty())
@@ -334,14 +310,15 @@ func TestLeastUpperBound(t *testing.T) {
 	for i := 0; i < 20; i += 2 {
 		tree = tree.Update(i, i)
 	}
-	p := tree.LeastUpperBound(4)
-	require.Equal(t, 4, p.Value())
-	p = tree.LeastUpperBound(5)
-	require.Equal(t, 6, p.Value())
-	p = tree.LeastUpperBound(22)
-	require.True(t, p.IsEmpty())
-	p = tree.LeastUpperBound(-1)
-	require.Equal(t, 0, p.Value())
+	kv, _ := tree.LeastUpperBound(4)
+	require.Equal(t, 4, kv.Value())
+	kv, _ = tree.LeastUpperBound(5)
+	require.Equal(t, 6, kv.Value())
+	kv, found := tree.LeastUpperBound(22)
+	require.False(t, found)
+	require.Nil(t, kv)
+	kv, _ = tree.LeastUpperBound(-1)
+	require.Equal(t, 0, kv.Value())
 }
 
 func TestGreatestLowerBound(t *testing.T) {
@@ -349,14 +326,15 @@ func TestGreatestLowerBound(t *testing.T) {
 	for i := 0; i < 20; i += 2 {
 		tree = tree.Update(i, i)
 	}
-	p := tree.GreatestLowerBound(4)
-	require.Equal(t, 4, p.Value())
-	p = tree.GreatestLowerBound(5)
-	require.Equal(t, 4, p.Value())
-	p = tree.GreatestLowerBound(22)
-	require.Equal(t, 18, p.Value())
-	p = tree.GreatestLowerBound(-1)
-	require.True(t, p.IsEmpty())
+	kv, _ := tree.GreatestLowerBound(4)
+	require.Equal(t, 4, kv.Value())
+	kv, _ = tree.GreatestLowerBound(5)
+	require.Equal(t, 4, kv.Value())
+	kv, _ = tree.GreatestLowerBound(22)
+	require.Equal(t, 18, kv.Value())
+	kv, found := tree.GreatestLowerBound(-1)
+	require.False(t, found)
+	require.Nil(t, kv)
 }
 
 func TestIter(t *testing.T) {
@@ -452,6 +430,7 @@ func TestUnMarshalJsonStringKey(t *testing.T) {
 	var x *Tree[string, int]
 	err = json.Unmarshal(serialized, &x)
 	require.NoError(t, err)
-	require.Equal(t, 2, x.Find("Hello").Value())
-	require.Equal(t, 4, x.Find("World").Value())
+
+	require.Equal(t, 2, x.Find("Hello"))
+	require.Equal(t, 4, x.Find("World"))
 }


### PR DESCRIPTION
Return bool indicating result is found.
Modify Pair interface by removing IsEmpty since empty
is a property of a tree; not a pair.