### PR TITLE
make Pair a struct instead of interface

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,12 +1,12 @@
 package persistent
 
-// Pair defines an interface for a Key / Value pair.
-type Pair[K any, V any] interface {
-	// Key Returns the key associated with the pair. Will return the zero value for K if IsEmpty is true.
-	Key() K
+// Pair defines a struct for a Key / Value pair.
+type Pair[K any, V any] struct {
+	// Key is the key associated with the pair.
+	Key K
 
-	// Value Returns the value associated with the pair. Will return the zero value for V if IsEmpty is true.
-	Value() V
+	// Value is the value associated with the pair.
+	Value V
 }
 
 // Iterator defines an interface for an iterator over a persistent data structure.

--- a/set.go
+++ b/set.go
@@ -72,7 +72,7 @@ func (s *Set[T]) LeastUpperBound(value T) (e T, ok bool) {
 		var ret T
 		return ret, false
 	}
-	return kv.Key(), true
+	return kv.Key, true
 }
 
 //GreatestLowerBound returns the largest element e in s, such that
@@ -88,7 +88,7 @@ func (s *Set[T]) GreatestLowerBound(value T) (T, bool) {
 		var ret T
 		return ret, false
 	}
-	return kv.Key(), true
+	return kv.Key, true
 }
 
 //Size returns the number of elements in the set.
@@ -156,5 +156,5 @@ func (s *SetIterator[T]) Next() bool {
 }
 
 func (s *SetIterator[T]) Current() T {
-	return s.wrapped.Current().Key()
+	return s.wrapped.Current().Key
 }

--- a/setEx.go
+++ b/setEx.go
@@ -71,7 +71,7 @@ func (s *SetEx[T]) LeastUpperBound(value T) (e T, ok bool) {
 		var ret T
 		return ret, false
 	}
-	return kv.Key(), true
+	return kv.Key, true
 }
 
 //GreatestLowerBound returns the largest element e in s, such that
@@ -87,7 +87,7 @@ func (s *SetEx[T]) GreatestLowerBound(value T) (T, bool) {
 		var ret T
 		return ret, false
 	}
-	return kv.Key(), true
+	return kv.Key, true
 }
 
 //Size returns the number of elements in the set.
@@ -155,5 +155,5 @@ func (s *SetExIterator[T]) Next() bool {
 }
 
 func (s *SetExIterator[T]) Current() T {
-	return s.wrapped.Current().Key()
+	return s.wrapped.Current().Key
 }

--- a/tree.go
+++ b/tree.go
@@ -294,7 +294,7 @@ func (n *Tree[K, V]) Size() int {
 //node then boolean is false.
 func (n *Tree[K, V]) LeastUpperBound(key K) (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n, false
+		return n.pair(), false
 	}
 
 	if n.key < key {
@@ -305,25 +305,25 @@ func (n *Tree[K, V]) LeastUpperBound(key K) (Pair[K, V], bool) {
 		ret, found := n.left.LeastUpperBound(key)
 
 		if !found {
-			return n, true
+			return n.pair(), true
 		}
 		return ret, true
 	}
 
-	return n, true
+	return n.pair(), true
 }
 
 //GreatestLowerBound returns the key-value-par for the largest node n such that n.Key() <= key. If there is no such
 //node then boolean is false.
 func (n *Tree[K, V]) GreatestLowerBound(key K) (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n, false
+		return n.pair(), false
 	}
 
 	if n.key < key {
 		ret, found := n.right.GreatestLowerBound(key)
 		if !found {
-			return n, true
+			return n.pair(), true
 		}
 		return ret, true
 	}
@@ -332,7 +332,7 @@ func (n *Tree[K, V]) GreatestLowerBound(key K) (Pair[K, V], bool) {
 		return n.left.GreatestLowerBound(key)
 	}
 
-	return n, true
+	return n.pair(), true
 }
 
 //Iter returns an in-order iterator for the tree.
@@ -375,7 +375,7 @@ func (n *Tree[K, V]) IterGte(glb K) Iterator[Pair[K, V]] {
 //is false
 func (n *Tree[K, V]) Least() (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return nil, false
+		return n.pair(), false
 	}
 
 	var ret = n
@@ -384,13 +384,13 @@ func (n *Tree[K, V]) Least() (Pair[K, V], bool) {
 		ret = ret.left
 	}
 
-	return ret, true
+	return ret.pair(), true
 }
 
 //Most returns the key-value-pair for the greatest element in the tree. If the tree is empty then boolean is false
 func (n *Tree[K, V]) Most() (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return nil, false
+		return n.pair(), false
 	}
 
 	var ret = n
@@ -399,14 +399,14 @@ func (n *Tree[K, V]) Most() (Pair[K, V], bool) {
 		ret = ret.right
 	}
 
-	return ret, false
+	return ret.pair(), false
 }
 
 func (n *Tree[K, V]) MarshalJSON() ([]byte, error) {
 	m := make(map[K]V)
 	iter := n.Iter()
 	for iter.Next() {
-		m[iter.Current().Key()] = iter.Current().Value()
+		m[iter.Current().Key] = iter.Current().Value
 	}
 	return json.Marshal(m)
 }
@@ -447,9 +447,13 @@ func (i *TreeIterator[K, V]) Current() Pair[K, V] {
 	if i.current.IsEmpty() {
 		panic("invalid iterator position")
 	}
-	return i.current
+	return i.current.pair()
 }
 
 func EmptyTree[K constraints.Ordered, V any]() *Tree[K, V] {
 	return nil
+}
+
+func (n *Tree[K, V]) pair() Pair[K, V] {
+	return Pair[K, V]{Key: n.Key(), Value: n.Value()}
 }

--- a/treeEx.go
+++ b/treeEx.go
@@ -301,7 +301,7 @@ func (n *TreeEx[K, V]) Size() int {
 //node then false is returned.
 func (n *TreeEx[K, V]) LeastUpperBound(key K) (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n, false
+		return n.pair(), false
 	}
 
 	if n.key.Less(key) {
@@ -312,25 +312,25 @@ func (n *TreeEx[K, V]) LeastUpperBound(key K) (Pair[K, V], bool) {
 		ret, found := n.left.LeastUpperBound(key)
 
 		if !found {
-			return n, true
+			return n.pair(), true
 		}
 		return ret, true
 	}
 
-	return n, true
+	return n.pair(), true
 }
 
 //GreatestLowerBound returns the key-value-par for the largest node n such that n.Key() <= key. If there is no such
 //node then false is returned.
 func (n *TreeEx[K, V]) GreatestLowerBound(key K) (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return n, false
+		return n.pair(), false
 	}
 
 	if n.key.Less(key) {
 		ret, found := n.right.GreatestLowerBound(key)
 		if !found {
-			return n, true
+			return n.pair(), true
 		}
 		return ret, true
 	}
@@ -339,7 +339,7 @@ func (n *TreeEx[K, V]) GreatestLowerBound(key K) (Pair[K, V], bool) {
 		return n.left.GreatestLowerBound(key)
 	}
 
-	return n, true
+	return n.pair(), true
 }
 
 //Iter returns an in-order iterator for the tree.
@@ -381,7 +381,7 @@ func (n *TreeEx[K, V]) IterGte(glb K) Iterator[Pair[K, V]] {
 //Least returns the key-value-pair for the lowest element in the tree. If the tree is empty, then return false
 func (n *TreeEx[K, V]) Least() (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return nil, false
+		return n.pair(), false
 	}
 
 	var ret = n
@@ -390,14 +390,14 @@ func (n *TreeEx[K, V]) Least() (Pair[K, V], bool) {
 		ret = ret.left
 	}
 
-	return ret, true
+	return ret.pair(), true
 }
 
 //Most returns the key-value-pair for the greatest element in the tree. If the tree is empty, the returned pair
 //is also empty
 func (n *TreeEx[K, V]) Most() (Pair[K, V], bool) {
 	if n.IsEmpty() {
-		return nil, false
+		return n.pair(), false
 	}
 
 	var ret = n
@@ -406,7 +406,7 @@ func (n *TreeEx[K, V]) Most() (Pair[K, V], bool) {
 		ret = ret.right
 	}
 
-	return ret, true
+	return ret.pair(), true
 }
 
 func (n *TreeEx[K, V]) MarshalJSON() ([]byte, error) {
@@ -428,7 +428,7 @@ func (n *TreeEx[K, V]) MarshalJSON() ([]byte, error) {
 			first = false
 		}
 
-		key := fmt.Sprint(iter.Current().Key())
+		key := fmt.Sprint(iter.Current().Key)
 		err = encoder.Encode(key)
 		if err != nil {
 			return nil, err
@@ -437,7 +437,7 @@ func (n *TreeEx[K, V]) MarshalJSON() ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		err = encoder.Encode(iter.Current().Value())
+		err = encoder.Encode(iter.Current().Value)
 		if err != nil {
 			return nil, err
 		}
@@ -492,9 +492,13 @@ func (i *TreeExIterator[K, V]) Current() Pair[K, V] {
 	if i.current.IsEmpty() {
 		panic("invalid iterator position")
 	}
-	return i.current
+	return i.current.pair()
 }
 
 func EmptyTreeEx[K Ordered[K], V any]() *TreeEx[K, V] {
 	return nil
+}
+
+func (n *TreeEx[K, V]) pair() Pair[K, V] {
+	return Pair[K, V]{Key: n.Key(), Value: n.Value()}
 }

--- a/treeEx_test.go
+++ b/treeEx_test.go
@@ -89,28 +89,28 @@ func TestExNilGLB(t *testing.T) {
 	var tree *TreeEx[Int, int]
 	kv, found := tree.GreatestLowerBound(2)
 	require.Falsef(t, found, "wtf?")
-	require.Nil(t, kv)
+	require.Zero(t, kv)
 }
 
 func TestExEmptyGLB(t *testing.T) {
 	var tree TreeEx[Int, int]
 	kv, found := tree.GreatestLowerBound(2)
 	require.Falsef(t, found, "wtf?")
-	require.Equal(t, &TreeEx[Int, int]{}, kv)
+	require.Zero(t, kv)
 }
 
 func TestExNilLUB(t *testing.T) {
 	var tree *TreeEx[Int, int]
 	kv, found := tree.LeastUpperBound(2)
 	require.Falsef(t, found, "wtf?")
-	require.Nil(t, kv)
+	require.Zero(t, kv)
 }
 
 func TestExEmptyLUB(t *testing.T) {
 	var tree TreeEx[Int, int]
 	kv, found := tree.LeastUpperBound(2)
 	require.Falsef(t, found, "wtf?")
-	require.Equal(t, &TreeEx[Int, int]{}, kv)
+	require.Zero(t, kv)
 }
 
 func TestExNilIter(t *testing.T) {
@@ -181,14 +181,14 @@ func TestExNilLeast(t *testing.T) {
 	var tree *TreeEx[Int, int]
 	kv, found := tree.Least()
 	require.False(t, found)
-	require.Nil(t, kv)
+	require.Zero(t, kv)
 }
 
 func TestExEmptyLeast(t *testing.T) {
 	var tree TreeEx[Int, int]
 	kv, found := tree.Least()
 	require.False(t, found)
-	require.Nil(t, kv)
+	require.Zero(t, kv)
 
 }
 
@@ -196,7 +196,7 @@ func TestExNilMost(t *testing.T) {
 	var tree *TreeEx[Int, int]
 	kv, found := tree.Most()
 	require.Falsef(t, found, "wtf?")
-	require.Nil(t, kv)
+	require.Zero(t, kv)
 
 }
 
@@ -204,7 +204,7 @@ func TestExEmptyMost(t *testing.T) {
 	var tree TreeEx[Int, int]
 	kv, found := tree.Most()
 	require.Falsef(t, found, "wtf?")
-	require.Nil(t, kv)
+	require.Zero(t, kv)
 }
 
 func TestExNilUpdate(t *testing.T) {
@@ -231,8 +231,8 @@ func TestExNilUpdate(t *testing.T) {
 	require.Zero(t, v)
 	i := tree2.Iter()
 	require.True(t, i.Next())
-	require.Equal(t, Int(2), i.Current().Key())
-	require.Equal(t, 3, i.Current().Value())
+	require.Equal(t, Int(2), i.Current().Key)
+	require.Equal(t, 3, i.Current().Value)
 	require.False(t, i.Next())
 }
 
@@ -263,8 +263,8 @@ func TestExEmptyUpdate(t *testing.T) {
 	require.Zero(t, v)
 	i := tree2.Iter()
 	require.True(t, i.Next())
-	require.Equal(t, Int(2), i.Current().Key())
-	require.Equal(t, 3, i.Current().Value())
+	require.Equal(t, Int(2), i.Current().Key)
+	require.Equal(t, 3, i.Current().Value)
 	require.False(t, i.Next())
 }
 
@@ -335,31 +335,31 @@ func TestExRotateLeftRight(t *testing.T) {
 }
 
 func TestExLeastUpperBound(t *testing.T) {
-	var tree *TreeEx[Int, int]
+	tree := EmptyTreeEx[Int, int]()
 	for i := 0; i < 20; i += 2 {
 		tree = tree.Update(Int(i), i)
 	}
 	p, _ := tree.LeastUpperBound(4)
-	require.Equal(t, 4, p.Value())
+	require.Equal(t, 4, p.Value)
 	p, _ = tree.LeastUpperBound(5)
-	require.Equal(t, 6, p.Value())
+	require.Equal(t, 6, p.Value)
 	_, found := tree.LeastUpperBound(22)
 	require.False(t, found)
 	p, _ = tree.LeastUpperBound(-1)
-	require.Equal(t, 0, p.Value())
+	require.Equal(t, 0, p.Value)
 }
 
 func TestExGreatestLowerBound(t *testing.T) {
-	var tree *TreeEx[Int, int]
+	tree := EmptyTreeEx[Int, int]()
 	for i := 0; i < 20; i += 2 {
 		tree = tree.Update(Int(i), i)
 	}
 	p, _ := tree.GreatestLowerBound(4)
-	require.Equal(t, 4, p.Value())
+	require.Equal(t, 4, p.Value)
 	p, _ = tree.GreatestLowerBound(5)
-	require.Equal(t, 4, p.Value())
+	require.Equal(t, 4, p.Value)
 	p, _ = tree.GreatestLowerBound(22)
-	require.Equal(t, 18, p.Value())
+	require.Equal(t, 18, p.Value)
 	_, found := tree.GreatestLowerBound(-1)
 	require.False(t, found)
 }
@@ -372,7 +372,7 @@ func TestExIter(t *testing.T) {
 	iter := tree.Iter()
 	j := 0
 	for iter.Next() {
-		require.Equal(t, j, iter.Current().Value())
+		require.Equal(t, j, iter.Current().Value)
 		j += 2
 	}
 	require.Equal(t, 20, j)
@@ -386,7 +386,7 @@ func TestExIterGte(t *testing.T) {
 	iter := tree.IterGte(7)
 	j := 8
 	for iter.Next() {
-		require.Equal(t, j, iter.Current().Value())
+		require.Equal(t, j, iter.Current().Value)
 		j += 2
 	}
 	require.Equal(t, 20, j)
@@ -440,7 +440,7 @@ func TestExUnmarshalJson(t *testing.T) {
 	iter := tree.Iter()
 	i := 0
 	for iter.Next() {
-		require.Equal(t, Int(i), iter.Current().Key())
+		require.Equal(t, Int(i), iter.Current().Key)
 		i += 2
 	}
 	require.Equal(t, 20, i)

--- a/tree_test.go
+++ b/tree_test.go
@@ -70,28 +70,28 @@ func TestNilGLB(t *testing.T) {
 	var tree *Tree[int, int]
 	kv, found := tree.GreatestLowerBound(2)
 	require.False(t, found)
-	require.Nil(t, kv)
+	require.Zero(t, kv)
 }
 
 func TestEmptyGLB(t *testing.T) {
 	var tree Tree[int, int]
 	kv, found := tree.GreatestLowerBound(2)
 	require.False(t, found)
-	require.Equal(t, &Tree[int, int]{}, kv)
+	require.Zero(t, kv)
 }
 
 func TestNilLUB(t *testing.T) {
 	var tree *Tree[int, int]
 	kv, found := tree.LeastUpperBound(2)
 	require.False(t, found)
-	require.Nil(t, kv)
+	require.Zero(t, kv)
 }
 
 func TestEmptyLUB(t *testing.T) {
 	var tree Tree[int, int]
 	kv, found := tree.LeastUpperBound(2)
 	require.False(t, found)
-	require.Equal(t, &Tree[int, int]{}, kv)
+	require.Zero(t, kv)
 }
 
 func TestNilIter(t *testing.T) {
@@ -208,8 +208,8 @@ func TestNilUpdate(t *testing.T) {
 
 	i := tree2.Iter()
 	require.True(t, i.Next())
-	require.Equal(t, 2, i.Current().Key())
-	require.Equal(t, 3, i.Current().Value())
+	require.Equal(t, 2, i.Current().Key)
+	require.Equal(t, 3, i.Current().Value)
 	require.False(t, i.Next())
 }
 
@@ -235,8 +235,8 @@ func TestEmptyUpdate(t *testing.T) {
 
 	i := tree2.Iter()
 	require.True(t, i.Next())
-	require.Equal(t, 2, i.Current().Key())
-	require.Equal(t, 3, i.Current().Value())
+	require.Equal(t, 2, i.Current().Key)
+	require.Equal(t, 3, i.Current().Value)
 	require.False(t, i.Next())
 }
 
@@ -311,14 +311,14 @@ func TestLeastUpperBound(t *testing.T) {
 		tree = tree.Update(i, i)
 	}
 	kv, _ := tree.LeastUpperBound(4)
-	require.Equal(t, 4, kv.Value())
+	require.Equal(t, 4, kv.Value)
 	kv, _ = tree.LeastUpperBound(5)
-	require.Equal(t, 6, kv.Value())
+	require.Equal(t, 6, kv.Value)
 	kv, found := tree.LeastUpperBound(22)
 	require.False(t, found)
-	require.Nil(t, kv)
+	require.Zero(t, kv)
 	kv, _ = tree.LeastUpperBound(-1)
-	require.Equal(t, 0, kv.Value())
+	require.Equal(t, 0, kv.Value)
 }
 
 func TestGreatestLowerBound(t *testing.T) {
@@ -327,14 +327,14 @@ func TestGreatestLowerBound(t *testing.T) {
 		tree = tree.Update(i, i)
 	}
 	kv, _ := tree.GreatestLowerBound(4)
-	require.Equal(t, 4, kv.Value())
+	require.Equal(t, 4, kv.Value)
 	kv, _ = tree.GreatestLowerBound(5)
-	require.Equal(t, 4, kv.Value())
+	require.Equal(t, 4, kv.Value)
 	kv, _ = tree.GreatestLowerBound(22)
-	require.Equal(t, 18, kv.Value())
+	require.Equal(t, 18, kv.Value)
 	kv, found := tree.GreatestLowerBound(-1)
 	require.False(t, found)
-	require.Nil(t, kv)
+	require.Zero(t, kv)
 }
 
 func TestIter(t *testing.T) {
@@ -345,7 +345,7 @@ func TestIter(t *testing.T) {
 	iter := tree.Iter()
 	j := 0
 	for iter.Next() {
-		require.Equal(t, j, iter.Current().Value())
+		require.Equal(t, j, iter.Current().Value)
 		j += 2
 	}
 	require.Equal(t, 20, j)
@@ -359,7 +359,7 @@ func TestIterGte(t *testing.T) {
 	iter := tree.IterGte(7)
 	j := 8
 	for iter.Next() {
-		require.Equal(t, j, iter.Current().Value())
+		require.Equal(t, j, iter.Current().Value)
 		j += 2
 	}
 	require.Equal(t, 20, j)
@@ -413,7 +413,7 @@ func TestUnmarshalJson(t *testing.T) {
 	iter := tree.Iter()
 	i := 0
 	for iter.Next() {
-		require.Equal(t, i, iter.Current().Key())
+		require.Equal(t, i, iter.Current().Key)
 		i += 2
 	}
 	require.Equal(t, 20, i)


### PR DESCRIPTION
Pair [or 2-tuple] doesn't need to be an interface
since there is no reason to have different implementations
for a key-value pair.